### PR TITLE
[FIX]캘린더 첫줄 이슈 수정

### DIFF
--- a/src/Components/Calendar/calendar.css
+++ b/src/Components/Calendar/calendar.css
@@ -108,6 +108,10 @@
   cursor: pointer;
 }
 
+.day.first-row {
+  border-top: none;
+}
+
 .day.today {
   background-color: #3c332b;
   color: #fff;

--- a/src/Components/Calendar/calendar.tsx
+++ b/src/Components/Calendar/calendar.tsx
@@ -167,20 +167,19 @@ const Calendar: React.FC<{
           .map((_, index) => (
             <div key={`empty-${index}`} className="empty-day" />
           ))}
-        {days.map(day => {
+        {days.map((day, index) => {
           const isToday =
             day === new Date().getDate() &&
             currentDate.getMonth() === new Date().getMonth() &&
             currentDate.getFullYear() === new Date().getFullYear()
 
-          // const eventCount = events.filter(
-          //   event => new Date(event.start.dateTime).getDate() === day
-          // ).length
+          // 첫 줄에 있는 날짜인지 확인
+          const isFirstRow = index + firstDayOfMonth < 7
 
           return (
             <div
               key={day}
-              className={`day ${isToday ? 'today' : ''}`}
+              className={`day ${isToday ? 'today' : ''} ${isFirstRow ? 'first-row' : ''}`}
               onClick={() => handleDayClick(day)}
             >
               <div className="day-number">{day}</div>


### PR DESCRIPTION
캘린더 요일 구분 선과 날짜의 첫줄이 겹치는 버그 수정
![스크린샷 2025-03-20 오전 12 04 51](https://github.com/user-attachments/assets/f50e205c-3ac1-4b89-b579-1c638452e398)

